### PR TITLE
[Feat] HomeScreen axios test 준비

### DIFF
--- a/components/Fab/Fab.tsx
+++ b/components/Fab/Fab.tsx
@@ -1,18 +1,19 @@
-import * as React from 'react';
-import {StyleSheet} from 'react-native';
-import {FAB} from 'react-native-paper';
+import * as React from "react";
+import { StyleSheet } from "react-native";
+import { FAB } from "react-native-paper";
 
 //icons
-import Zoomicon from '../../assets/icons/icon-zoom.png';
 
-const CustomFab = () => (
-  <FAB
-    icon="Zoomicon"
-    mode="flat"
-    style={styles.fab}
-    onPress={() => console.log('Pressed')}
-  />
-);
+export interface CustomFabProps {
+  icon?: any;
+  mode?: any;
+  style?: any;
+  onPress?: any;
+}
+
+const CustomFab = ({ icon, mode, style, onPress }: CustomFabProps) => {
+  return <FAB icon={icon} mode="flat" style={style} onPress={onPress} />;
+};
 
 // size
 // Type : 'small' | 'medium' | 'large'
@@ -24,7 +25,7 @@ const CustomFab = () => (
 
 const styles = StyleSheet.create({
   fab: {
-    position: 'absolute',
+    position: "absolute",
     margin: 16,
     right: 0,
     bottom: 0,

--- a/screens/HomeScreen/HomeScreen.tsx
+++ b/screens/HomeScreen/HomeScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ScrollView, Button, View } from "react-native";
+import { ScrollView, View } from "react-native";
 import CustomButton from "../../components/Button/Button";
 // import CustomFab from "../../components/Fab/Fab";
 // import ListItem from "../../components/ListItem/ListItem";
@@ -13,18 +13,19 @@ import WeeklyTheme from "./components/WeeklyTheme/WeeklyTheme";
 import NearByTheme from "./components/NearByTheme/NearByTheme";
 import BookmarkedTheme from "./components/BookmarkedTheme/BookmarkedTheme";
 import Header from "../../components/Header/Header";
+import Button from "../../components/Button/Button";
 
-const HomeScreen = ({ }) => {
+const HomeScreen = ({}) => {
   return (
     <View>
       <ScrollView>
         <Header />
         <HomeTitle />
         <Input label="테마 검색" />
+        <Button value="검색" size="small" mode="static" border="square" />
         <WeeklyTheme />
         <NearByTheme />
         <BookmarkedTheme />
-        <CustomButton value="Press" />
       </ScrollView>
     </View>
   );

--- a/screens/HomeScreen/components/NearByTheme/NearByTheme.tsx
+++ b/screens/HomeScreen/components/NearByTheme/NearByTheme.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { ScrollView, Button, View, Text, StyleSheet } from "react-native";
+import { ScrollView, View, Text, StyleSheet } from "react-native";
 // import Input from "../../../../components/Input/Input";
 import Geolocation from "@react-native-community/geolocation";
 import CustomMap from "../../../../components/Maps/Map";
+import { useNavigation } from "@react-navigation/native";
+import CustomFab from "../../../../components/Fab/Fab";
+import Zoomicon from "../../../../assets/icons/icon-zoom.png";
+import SearchScreen from "../../../SearchScreen/SearchScreen";
 
 import { PermissionsAndroid } from "react-native";
 import { Region, Marker } from "react-native-maps";
@@ -56,6 +60,13 @@ const NearByTheme = () => {
       { enableHighAccuracy: false, timeout: 15000, maximumAge: 10000 },
     );
   }, []);
+  const navigation = useNavigation();
+
+  const handleFABClick = () => {
+    // navigation.navigate("SearchScreen");
+    console.log("FAB 버튼이 눌렸습니다.");
+  };
+
   return (
     <View style={styles.container}>
       <Text>내 주변</Text>
@@ -63,6 +74,12 @@ const NearByTheme = () => {
         <CustomMap region={region}>
           <Marker coordinate={region} title={"내 위치"} />
         </CustomMap>
+        {/* <Button style={styles.buttonContainer} /> */}
+        <CustomFab
+          icon={Zoomicon}
+          style={styles.buttonContainer}
+          onPress={handleFABClick}
+        />
       </View>
     </View>
   );
@@ -79,6 +96,12 @@ const styles = StyleSheet.create({
   },
   mapContainer: {
     flex: 1,
+  },
+  buttonContainer: {
+    position: "absolute",
+    top: 10,
+    right: 10,
+    zIndex: 10,
   },
 });
 

--- a/screens/HomeScreen/components/WeeklyTheme/WeeklyTheme.tsx
+++ b/screens/HomeScreen/components/WeeklyTheme/WeeklyTheme.tsx
@@ -1,13 +1,63 @@
-import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import React, { useEffect, useState } from "react";
+import { View, Text, StyleSheet, Image, FlatList } from "react-native";
+import { getThemeSort } from "../../../../recoil/selector/selector";
+import { useRecoilValue, useRecoilValueLoadable } from "recoil";
 // import Input from "../../../components/Input/Input";
 
+interface Poster {
+  id: string;
+  venue: string;
+  title: string;
+  poster: string;
+  explanation: string;
+  level: number;
+  minHeadcount: number;
+  maxHeadcount: number;
+}
+
+// NOTE useState로도 해보고 recoil에서도 import 해보고 써보려는데
+// NOTE getThemeSort axios 자체가 지금 제대로 안 적힌 것 같아 void로 나와용
+
 const WeeklyTheme = () => {
+  // const postersLoadable = useRecoilValueLoadable(getThemeSort);
+
+  // const renderItem = ({ item }: { item: Poster }) => (
+  //   <View>
+  //     <Image source={{ uri: item.poster }} />
+  //     <Text>{item.title}</Text>
+  //     <Text>{item.venue}</Text>
+  //   </View>
+  // );
+
+  // let content;
+
+  // // TODO hasValue가 null일 때 에러가 나는지, axios 통신으로 Data가 받아오는지
+  // // TODO Test가 미비한 상태입니다.
+  // switch (postersLoadable.state) {
+  //   case "hasValue":
+  //     content = (
+  //       <FlatList
+  //         data={postersLoadable.contents.data}
+  //         renderItem={renderItem}
+  //         keyExtractor={item => item.id}
+  //         horizontal
+  //         showsHorizontalScrollIndicator={false}
+  //       />
+  //     );
+  //     break;
+  //   case "loading":
+  //     content = <Text>Loading...</Text>;
+  //     break;
+  //   case "hasError":
+  //     content = <Text>Error: {postersLoadable.contents.message}</Text>;
+  //     break;
+  // }
   return (
     <View>
       <Text>
         {}월 {}주차 인기 테마
       </Text>
+      {/* {content} */}
       <View style={styles}>
         <Text>크롤링한 포스터가 들어올 공간입니다</Text>
       </View>

--- a/screens/SearchScreen/SearchScreen.tsx
+++ b/screens/SearchScreen/SearchScreen.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import {View, Button} from 'react-native';
+import React from "react";
+import { View, Button } from "react-native";
 
 const SearchScreen = () => {
   return (


### PR DESCRIPTION
## Work Description ✏️

- HomeScreen axios test 준비
- 지도 우측 상단 FAB버튼 위치
- 추후 stack navigation 쌓고 SearchScreen으로 이동

## Share 🤔

- FAB이 눌렸을 땐 내 위치 기반 지도가 랜더링되어야 하고
- bottomTab으로 올때는 테마 리스트가 정렬이 되어야 한다면
- 어떤 방식으로 구현이 가능할까요?

## Related issue 🛠

- Closes #65 
